### PR TITLE
bugfix for the reconstruction part and the squash function and the margin&reconsturction loss function.

### DIFF
--- a/capsule_conv_layer.py
+++ b/capsule_conv_layer.py
@@ -19,7 +19,7 @@ class CapsuleConvLayer(nn.Module):
                                out_channels=out_channels,
                                kernel_size=9, # fixme constant
                                stride=1,
-                               bias=False)
+                               bias=True)
 
         self.relu = nn.ReLU(inplace=True)
 

--- a/capsule_layer.py
+++ b/capsule_layer.py
@@ -31,6 +31,7 @@ class CapsuleLayer(nn.Module):
         self.in_units = in_units
         self.in_channels = in_channels
         self.num_units = num_units
+        self.unit_size = unit_size
         self.use_routing = use_routing
 
         if self.use_routing:
@@ -45,7 +46,7 @@ class CapsuleLayer(nn.Module):
                 unit = ConvUnit(in_channels=in_channels)
                 self.add_module("unit_" + str(unit_idx), unit)
                 return unit
-            self.units = [create_conv_unit(i) for i in range(self.num_units)]
+            self.units = [create_conv_unit(i) for i in range(self.unit_size)]
 
     @staticmethod
     def squash(s):
@@ -64,13 +65,13 @@ class CapsuleLayer(nn.Module):
     def no_routing(self, x):
         # Get output for each unit.
         # Each will be (batch, channels, height, width).
-        u = [self.units[i](x) for i in range(self.num_units)]
+        u = [self.units[i](x) for i in range(self.unit_size)]
 
-        # Stack all unit outputs (batch, unit, channels, height, width).
+        # Stack all unit outputs (batch, unit_size, channels, height, width).
         u = torch.stack(u, dim=1)
 
-        # Flatten to (batch, unit, output).
-        u = u.view(x.size(0), self.num_units, -1)
+        # Flatten to (batch, unit_size, output).
+        u = u.view(x.size(0), self.unit_size, -1)
 
         # Return squashed outputs.
         return CapsuleLayer.squash(u)

--- a/capsule_network.py
+++ b/capsule_network.py
@@ -75,8 +75,8 @@ class CapsuleNetwork(nn.Module):
         zero = Variable(torch.zeros(1)).cuda()
         m_plus = 0.9
         m_minus = 0.1
-        max_l = torch.max(m_plus - v_mag, zero).view(batch_size, -1)
-        max_r = torch.max(v_mag - m_minus, zero).view(batch_size, -1)
+        max_l = torch.max(m_plus - v_mag, zero).view(batch_size, -1) ** 2
+        max_r = torch.max(v_mag - m_minus, zero).view(batch_size, -1) ** 2
 
         # This is equation 4 from the paper.
         loss_lambda = 0.5
@@ -118,11 +118,11 @@ class CapsuleNetwork(nn.Module):
             vutils.save_image(output_image, "reconstruction.png")
         self.reconstructed_image_count += 1
 
-        # The reconstruction loss is the mean squared difference between the input image and reconstructed image.
+        # The reconstruction loss is the sum squared difference between the input image and reconstructed image.
         # Multiplied by a small number so it doesn't dominate the margin (class) loss.
         error = (output - images).view(output.size(0), -1)
         error = error**2
-        error = torch.mean(error, dim=1) * 0.0005
+        error = torch.sum(error, dim=1) * 0.0005
 
         # Average over batch
         if size_average:

--- a/capsule_network.py
+++ b/capsule_network.py
@@ -43,8 +43,8 @@ class CapsuleNetwork(nn.Module):
                                     unit_size=primary_unit_size,
                                     use_routing=False)
 
-        self.digits = CapsuleLayer(in_units=num_primary_units,
-                                   in_channels=primary_unit_size,
+        self.digits = CapsuleLayer(in_units=primary_unit_size,
+                                   in_channels=num_primary_units,
                                    num_units=num_output_units,
                                    unit_size=output_unit_size,
                                    use_routing=True)

--- a/main.py
+++ b/main.py
@@ -46,8 +46,8 @@ test_loader = torch.utils.data.DataLoader(test_dataset, batch_size=test_batch_si
 
 conv_inputs = 1
 conv_outputs = 256
-num_primary_units = 8
-primary_unit_size = 32 * 6 * 6  # fixme get from conv2d
+num_primary_units = 32 * 6 * 6
+primary_unit_size = 8  # fixme get from conv2d
 output_unit_size = 16
 
 network = CapsuleNetwork(image_width=28,


### PR DESCRIPTION
#2 
Get 98% accuracy in 1st epoch now.
Original code is so great and neat. thanks a lot :)
But I found some bugs here.

fixbug1: Use the correct capsule to reconstruct the input image rather than longest capsule. 
fixbug2: Use the squash function to squash the right dimension(unit_size 8) in primary capsule, It have a great impact on the model accuracy. `CapsuleLayer.squash(u, dim=1)`(The digit part squash function seems not right, and the most weird thing is if I squash the right dim which is capsule size 16, model can't be train correctly.)
fixbug3: The margin loss function lack of a square term.
fixbug4: The reconstruction_loss function should minimize the sum of squared differences instead of the mean squared differences.(as the capsule paper said)
